### PR TITLE
Fix: Social overlap wrong address

### DIFF
--- a/src/pages/TokenBalances/Socials/FollowCombination.tsx
+++ b/src/pages/TokenBalances/Socials/FollowCombination.tsx
@@ -42,7 +42,7 @@ const minItemCount = 1;
 type FollowCombinationSectionProps = {
   dappName: string;
   onFollowClick?: (params: FollowCombinationParams) => void;
-  onShowMoreClick?: (values: string[], type?: string) => void;
+  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
 } & FollowCombinationSectionType;
 
 function FollowCombinationSection({
@@ -91,7 +91,7 @@ function FollowCombinationSection({
           <li
             onClick={() => {
               if (showMax && values.length > maxItemCount) {
-                onShowMoreClick?.([values[0].profileName1], dappName);
+                onShowMoreClick?.(name, [values[0].profileName1], dappName);
                 return;
               }
             }}
@@ -127,7 +127,7 @@ function FollowInfo({ icon, text, className }: FollowInfoProps) {
 
 type FollowCombinationProps = {
   onFollowClick?: (params: FollowCombinationParams) => void;
-  onShowMoreClick?: (values: string[], type?: string) => void;
+  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
 } & FollowCombinationType;
 
 export function FollowCombination({

--- a/src/pages/TokenBalances/Socials/FollowCombination.tsx
+++ b/src/pages/TokenBalances/Socials/FollowCombination.tsx
@@ -42,7 +42,7 @@ const minItemCount = 1;
 type FollowCombinationSectionProps = {
   dappName: string;
   onFollowClick?: (params: FollowCombinationParams) => void;
-  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
+  onShowMoreClick?: (values: string[], type?: string) => void;
 } & FollowCombinationSectionType;
 
 function FollowCombinationSection({
@@ -91,7 +91,7 @@ function FollowCombinationSection({
           <li
             onClick={() => {
               if (showMax && values.length > maxItemCount) {
-                onShowMoreClick?.(name, [values[0].profileName1], dappName);
+                onShowMoreClick?.([name], dappName);
                 return;
               }
             }}
@@ -127,7 +127,7 @@ function FollowInfo({ icon, text, className }: FollowInfoProps) {
 
 type FollowCombinationProps = {
   onFollowClick?: (params: FollowCombinationParams) => void;
-  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
+  onShowMoreClick?: (values: string[], type?: string) => void;
 } & FollowCombinationType;
 
 export function FollowCombination({

--- a/src/pages/TokenBalances/Socials/SocialCombination.tsx
+++ b/src/pages/TokenBalances/Socials/SocialCombination.tsx
@@ -6,11 +6,11 @@ const maxItemCount = 7;
 const minItemCount = 1;
 
 type SocialSectionProps = {
-  name?: string;
+  name: string;
   values: ReactNode[];
   type?: string;
   onAddressClick?: (value: unknown, type?: string) => void;
-  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
+  onShowMoreClick?: (values: string[], type?: string) => void;
 };
 
 function SocialSection({
@@ -61,7 +61,7 @@ function SocialSection({
           <li
             onClick={() => {
               if (showMax && values.length > maxItemCount) {
-                onShowMoreClick?.(name || '', values as string[], type);
+                onShowMoreClick?.([name], type);
                 return;
               }
             }}
@@ -81,7 +81,7 @@ type SocialProps = {
   image: string;
   sections?: SocialSectionType[];
   onAddressClick?: (value: unknown, type?: string) => void;
-  onShowMoreClick?: (address: string, values: string[], type?: string) => void;
+  onShowMoreClick?: (values: string[], type?: string) => void;
 };
 
 export function SocialCombination({

--- a/src/pages/TokenBalances/Socials/SocialsOverlap.tsx
+++ b/src/pages/TokenBalances/Socials/SocialsOverlap.tsx
@@ -191,12 +191,10 @@ function SocialsOverlapComponent() {
     isOpen: boolean;
     dataType?: string;
     addresses: string[];
-    modalFor: string;
   }>({
     isOpen: false,
     dataType: '',
-    addresses: [],
-    modalFor: ''
+    addresses: []
   });
 
   const [{ address }, setData] = useSearchInput();
@@ -215,24 +213,19 @@ function SocialsOverlapComponent() {
     }
   }, [fetchData, address]);
 
-  const handleShowMoreClick = useCallback(
-    (address: string, values: string[], type?: string) => {
-      setModalData({
-        isOpen: true,
-        dataType: type,
-        addresses: values,
-        modalFor: address
-      });
-    },
-    []
-  );
+  const handleShowMoreClick = useCallback((values: string[], type?: string) => {
+    setModalData({
+      isOpen: true,
+      dataType: type,
+      addresses: values
+    });
+  }, []);
 
   const handleModalClose = useCallback(() => {
     setModalData({
       isOpen: false,
       dataType: '',
-      addresses: [],
-      modalFor: ''
+      addresses: []
     });
   }, []);
 
@@ -407,10 +400,10 @@ function SocialsOverlapComponent() {
       </div>
       {modalData.isOpen && (
         <LazyAddressesModal
-          heading={`All ENS names of ${modalData.modalFor}`}
+          heading={`All ENS names of ${modalData.addresses[0]}`}
           isOpen={modalData.isOpen}
           dataType={modalData.dataType}
-          addresses={[modalData.modalFor]}
+          addresses={modalData.addresses}
           onRequestClose={handleModalClose}
           onAddressClick={handleAddressClick}
         />

--- a/src/pages/TokenBalances/Socials/SocialsOverlap.tsx
+++ b/src/pages/TokenBalances/Socials/SocialsOverlap.tsx
@@ -410,7 +410,7 @@ function SocialsOverlapComponent() {
           heading={`All ENS names of ${modalData.modalFor}`}
           isOpen={modalData.isOpen}
           dataType={modalData.dataType}
-          addresses={address}
+          addresses={[modalData.modalFor]}
           onRequestClose={handleModalClose}
           onAddressClick={handleAddressClick}
         />


### PR DESCRIPTION
1. Fix the issue of passing wrong addresses (both identities) in LazyAddressModal in the Social Overlap component
2. Reuse `addresses` instead `modalFor` modal property