### PR TITLE
Fix: Onchain Profile Image issue

### DIFF
--- a/src/pages/OnchainGraph/CommonScore/Score/utils.ts
+++ b/src/pages/OnchainGraph/CommonScore/Score/utils.ts
@@ -23,7 +23,8 @@ export function getProfileDataFromSocial(
   }
 
   const lens = social?.lensSocials?.[0] || null;
-  const farcaster = social?.farcasterSocials?.[0] || null;
+  const farcaster =
+    social?.farcasterSocials?.find(item => item.profileImage) || null;
 
   return {
     domain: domain || null,


### PR DESCRIPTION
farecaster profile image was not shown if first social is doesn't have profile image