### PR TITLE
Fix: Advance search flow bug fixes

### DIFF
--- a/src/Components/AdvancedSearch/index.tsx
+++ b/src/Components/AdvancedSearch/index.tsx
@@ -347,11 +347,6 @@ export default function AdvancedSearch({
       // append space to the value
       const finalValue = value.trim() + ' ';
       onChange(finalValue);
-      const mentionInputEl =
-        document.querySelector<HTMLTextAreaElement>(mentionInputSelector);
-      // focus and put caret to last position
-      mentionInputEl?.focus();
-      mentionInputEl?.setSelectionRange(finalValue.length, finalValue.length);
     }
     onClose();
   };

--- a/src/Components/Search/Search.tsx
+++ b/src/Components/Search/Search.tsx
@@ -18,7 +18,7 @@ import AdvancedSearch from '../AdvancedSearch';
 import { isMobileDevice } from '../../utils/isMobileDevice';
 
 export const tokenHoldersPlaceholder =
-  'Use @ mention or enter any token contract address';
+  'Type "@" to search by name, or enter any contract address, or any POAP event ID';
 export const tokenBalancesPlaceholder =
   'Enter 0x, name.eth, fc_fname:name, or name.lens';
 
@@ -354,6 +354,14 @@ export const Search = memo(function Search() {
     setAdvancedSearchData(prev => ({ ...prev, visible: false }));
   }, []);
 
+  const handleAdvanceSearchOnChange = useCallback(
+    (value: string) => {
+      setValue(value);
+      setTimeout(() => handleSubmit(value), 200);
+    },
+    [handleSubmit]
+  );
+
   const inputPlaceholder = isTokenBalances
     ? tokenBalancesPlaceholder
     : tokenHoldersPlaceholder;
@@ -455,7 +463,7 @@ export const Search = memo(function Search() {
                 mentionValue={value}
                 displayValueStartIndex={advancedSearchData.startIndex}
                 displayValueEndIndex={advancedSearchData.endIndex}
-                onChange={setValue}
+                onChange={handleAdvanceSearchOnChange}
                 onClose={hideAdvancedSearch}
               />
             </>

--- a/src/pages/TokenBalances/SocialFollows/MentionInput.tsx
+++ b/src/pages/TokenBalances/SocialFollows/MentionInput.tsx
@@ -141,6 +141,11 @@ export function MentionInput({
     setAdvancedSearchData(prev => ({ ...prev, visible: false }));
   }, []);
 
+  const handleAdvanceSearchOnChange = (value: string) => {
+    setValue(value);
+    setTimeout(() => handleSubmit(value), 200);
+  };
+
   const enableAdvancedSearch = !isMobile;
 
   return (
@@ -191,7 +196,7 @@ export function MentionInput({
               mentionValue={value}
               displayValueStartIndex={advancedSearchData.startIndex}
               displayValueEndIndex={advancedSearchData.endIndex}
-              onChange={setValue}
+              onChange={handleAdvanceSearchOnChange}
               onClose={hideAdvancedSearch}
             />
           </div>


### PR DESCRIPTION
### Fixes
1. Change Tokens holders mention inputs' placeholder to `Type "@" to search by name, or enter any contract address, or any POAP event ID.`
2. On selecting an item from the advanced search, directly add mention without needing to press enter