### PR TITLE
Fix: ERC20 asset image fix and fc_fname fix

### DIFF
--- a/src/Components/AdvancedSearch/Asset.tsx
+++ b/src/Components/AdvancedSearch/Asset.tsx
@@ -59,7 +59,7 @@ export default function Asset({
           src={image?.medium}
           className={classNames(
             'aspect-square',
-            tokenType === 'ERC20' && !image?.medium ? 'h-[50%]' : 'h-full'
+            tokenType === 'ERC20' && image?.medium ? 'h-[50%]' : 'h-full'
           )}
           errorPlaceholderClassName="!h-full"
         />

--- a/src/Components/Search/Search.tsx
+++ b/src/Components/Search/Search.tsx
@@ -63,7 +63,7 @@ const defaultAdvancedSearchData: AdvancedSearchData = {
 };
 
 const ALLOWED_ADDRESS_REGEX =
-  /0x[a-fA-F0-9]+|.*\.(eth|lens|cb\.id)|(fc_name:|lens\/@).*/;
+  /0x[a-fA-F0-9]+|.*\.(eth|lens|cb\.id)|(fc_fname:|lens\/@).*/;
 
 const padding = '  ';
 


### PR DESCRIPTION
### Hot Fixes
1. Set image height 50% for ERC20 tokens in Advanced Search
2. Correctly support `fc_fname` in Search in token balances page